### PR TITLE
Tweak class path computation

### DIFF
--- a/src/main/scala/com/virtuslab/stacktraces/core/Stacktraces.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/core/Stacktraces.scala
@@ -21,11 +21,11 @@ import java.nio.file.Paths
 object Stacktraces:
   lazy val classpathDirectories = ClasspathDirectoriesLoader.getClasspathDirectories 
 
-  def convertToPrettyStackTrace(e: Exception): PrettyException =
+  def convertToPrettyStackTrace(e: Throwable): PrettyException =
     convertToPrettyStackTrace(e, classpathDirectories)
 
   def convertToPrettyStackTrace(
-    e: Exception,
+    e: Throwable,
     classpathDirectories: List[ClasspathWrapper]
   ): PrettyException =
     val st = filterInternalStackFrames(e.getStackTrace).flatMap { ste =>

--- a/src/main/scala/com/virtuslab/stacktraces/core/Stacktraces.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/core/Stacktraces.scala
@@ -1,5 +1,6 @@
 package org.virtuslab.stacktraces.core
 
+import org.virtuslab.stacktraces.model.ClasspathWrapper
 import org.virtuslab.stacktraces.model.TastyWrapper
 import org.virtuslab.stacktraces.model.PrettyException
 import org.virtuslab.stacktraces.model.PrettyStackTraceElement
@@ -21,6 +22,12 @@ object Stacktraces:
   lazy val classpathDirectories = ClasspathDirectoriesLoader.getClasspathDirectories 
 
   def convertToPrettyStackTrace(e: Exception): PrettyException =
+    convertToPrettyStackTrace(e, classpathDirectories)
+
+  def convertToPrettyStackTrace(
+    e: Exception,
+    classpathDirectories: List[ClasspathWrapper]
+  ): PrettyException =
     val st = filterInternalStackFrames(e.getStackTrace).flatMap { ste =>
       val tastyFilesLocator = TastyFilesLocator(classpathDirectories)
       tastyFilesLocator.findTastyFile(ste.getClassName) match

--- a/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
@@ -14,7 +14,9 @@ object ClasspathDirectoriesLoader:
     case _ => getUrls(cl.getParent)
 
   def getClasspath: List[File] =
-    getUrls(getClass.getClassLoader).map(_.toURI).map(File(_)).toList
+    getClasspath(getClass.getClassLoader)
+  def getClasspath(loader: ClassLoader): List[File] =
+    getUrls(loader).map(_.toURI).map(File(_)).toList
 
   def getClasspathDirectories: List[ClasspathWrapper] =
     getClasspathDirectories(getClasspath)

--- a/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
@@ -8,15 +8,15 @@ import org.virtuslab.stacktraces.model.ClasspathWrapper
 
 object ClasspathDirectoriesLoader:
 
-  private def getUrls(cl: ClassLoader): Array[URL] = cl match
+  private def classpath(cl: ClassLoader): Array[File] = cl match
     case null => Array()
-    case u: URLClassLoader => u.getURLs ++ getUrls(cl.getParent)
-    case _ => getUrls(cl.getParent)
+    case u: URLClassLoader => u.getURLs.map(_.toURI).map(new File(_)) ++ classpath(cl.getParent)
+    case _ => classpath(cl.getParent)
 
   def getClasspath: List[File] =
     getClasspath(Thread.currentThread().getContextClassLoader)
   def getClasspath(loader: ClassLoader): List[File] =
-    getUrls(loader).map(_.toURI).map(File(_)).toList
+    classpath(loader).toList
 
   def getClasspathDirectories: List[ClasspathWrapper] =
     getClasspathDirectories(getClasspath)

--- a/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
@@ -13,7 +13,7 @@ object ClasspathDirectoriesLoader:
     case u: URLClassLoader => u.getURLs ++ getUrls(cl.getParent)
     case _ => getUrls(cl.getParent)
 
-  private def getClasspath: List[File] =
+  def getClasspath: List[File] =
     getUrls(getClass.getClassLoader).map(_.toURI).map(File(_)).toList
 
   def getClasspathDirectories: List[ClasspathWrapper] =

--- a/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
@@ -17,8 +17,9 @@ object ClasspathDirectoriesLoader:
     getUrls(getClass.getClassLoader).map(_.toURI).map(File(_)).toList
 
   def getClasspathDirectories: List[ClasspathWrapper] =
-    val classPathFiles = getClasspath
-    val (directories, jars) = classPathFiles.partition(_.isDirectory)
+    getClasspathDirectories(getClasspath)
+  def getClasspathDirectories(classPathFiles: Seq[File]): List[ClasspathWrapper] =
+    val (directories, jars) = classPathFiles.toList.partition(_.isDirectory)
     val allDirectories = projectClassesToClasspathWrappers(directories) ++ jarsToClasspathWrappers(jars)
     allDirectories
 

--- a/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
@@ -11,6 +11,12 @@ object ClasspathDirectoriesLoader:
   private def classpath(cl: ClassLoader): Array[File] = cl match
     case null => Array()
     case u: URLClassLoader => u.getURLs.map(_.toURI).map(new File(_)) ++ classpath(cl.getParent)
+    case cl if cl.getClass.getName == "jdk.internal.loader.ClassLoaders$AppClassLoader" =>
+      // Required with JDK >= 9
+      sys.props.getOrElse("java.class.path", "")
+        .split(File.pathSeparator)
+        .filter(_.nonEmpty)
+        .map(new File(_))
     case _ => classpath(cl.getParent)
 
   def getClasspath: List[File] =

--- a/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/io/ClasspathDirectoriesLoader.scala
@@ -14,7 +14,7 @@ object ClasspathDirectoriesLoader:
     case _ => getUrls(cl.getParent)
 
   def getClasspath: List[File] =
-    getClasspath(getClass.getClassLoader)
+    getClasspath(Thread.currentThread().getContextClassLoader)
   def getClasspath(loader: ClassLoader): List[File] =
     getUrls(loader).map(_.toURI).map(File(_)).toList
 

--- a/src/main/scala/com/virtuslab/stacktraces/model/model.scala
+++ b/src/main/scala/com/virtuslab/stacktraces/model/model.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 case class ClasspathWrapper(file: File, jarName: Option[String])
 case class TastyWrapper(file: File, jarName: Option[String])
-case class PrettyException(original: Exception, prettyStackTrace: List[PrettyStackTraceElement])
+case class PrettyException(original: Throwable, prettyStackTrace: List[PrettyStackTraceElement])
 
 enum ElementType(val name: String):
   case Method extends ElementType("method")


### PR DESCRIPTION
These are changes I found handy when using this in "project eel". I split that in many commits (just squash them…), but the overall goals are to
- default to `Thread.currentThread().getContextClassLoader` to compute the class path (rather than `getClass.getClassLoader`, which may only point to a particular class loader in the class loader hierarchy, and can miss things in child class loaders)
- allow users to pass their own class path if they want to, just in case
- add support for JDK >= 9 AppClassLoader (which contains the main class path in JDK >= 9, and is not a URLClassLoader).